### PR TITLE
Missing dependency @parcel/plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
   },
   "author": "Vladimir Mikulic",
   "license": "MIT",
+  "dependencies": {
+    "@parcel/plugin": "^2.5.0",
+  },
   "devDependencies": {
     "parcel": "^2.5.0"
   }


### PR DESCRIPTION
All dependencies required for the package to run should be included in package.json. In basic setups where no other package depends on @parcel/plugin, this will cause parcel to crash.